### PR TITLE
Fix broken data updates: migrate NSDL search to nsdl.com JSON API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ version := $(shell date +%Y.%-m.%-d)
         INE INF IN9 IN0 IN1 IN2 IN3 IN4 INA INB INC IND ING
 
 check:
-	for cmd in pup jq parallel curl sed; do \
+	for cmd in jq curl sed; do \
 		command -v $$cmd >/dev/null 2>&1 || { echo >&2 "I require $$cmd but it's not installed."; exit 1; }; \
 	done
 
-# Fetch ISINs from NSDL master search across every issuer class.
-# Large classes (INE, INF, IN9) are partial-fetched ~1/100 pages per day,
-# rotating through the full corpus in 100 days. Small classes pull every page.
+# Fetch ISINs from NSDL search API across every issuer class.
+# With 50k-row API pages every class fits in a few pages, so all classes
+# fetch fully; --partial-okay only kicks in if the API shrinks page sizes.
 SEARCH_CSV := search.csv
 
 $(SEARCH_CSV): INE INF IN9 IN0 IN1 IN2 IN3 IN4 INA INB INC IND ING

--- a/src/fetch.sh
+++ b/src/fetch.sh
@@ -1,50 +1,23 @@
 #!/bin/bash
+set -euo pipefail
 
-export PUP_BINARY="$(which pup)"
-
-if ! command -v pup &> /dev/null
-then
-  wget --quiet https://github.com/ericchiang/pup/releases/download/v0.4.0/pup_v0.4.0_linux_amd64.zip -O pup.zip
-  echo "ec3d29e9fb375b87ac492c8b546ad6be84b0c0b49dab7ff4c6b582eac71ba01c  pup.zip" | sha256sum --strict --check
-  unzip -o pup.zip
-  rm pup.zip
-  chmod +x ./pup
-  export PUP_BINARY="$(pwd)/pup"
-fi
+API="https://nsdl.com/web/api/v1/participant/search?search_type=DetailedSearch&name="
+PER_PAGE=50000
+# --fail makes HTTP 4xx/5xx (and WAF error pages) abort loudly instead of feeding jq garbage
+CURL_ARGS=(-sS --fail --retry 10 --connect-timeout 30 --retry-max-time 100
+  --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
 
 # Call with INX Page_num file_name
 function fetch_page() {
   echo "[+] $1/$2"
-  curl --insecure "https://nsdl.co.in/master_search_res.php" \
-    --no-progress-meter \
-    --user-agent "Mozilla/Gecko/Firefox/58.0" \
-    --retry 10 \
-    --connect-timeout 30 \
-    --cacert src/GeoTrustTLSRSACAG1.crt.pem \
-    --retry-max-time 100 \
-    --data cnum=$1 \
-    --data "page_no=$2" | \
-  $PUP_BINARY '#nsdl-tables tr json{}' | \
-  # Generate a CSV (this contains the header row as well)
-  jq --raw-output '.[] | [.children[1].children[0].text, .children[2].text, .children[3].text,.children[4].text,.children[5].text]|@csv' | \
-  # Convert &amp; to &
-  sed 's/&amp;/\&/g' | \
-  # Drop the first row
-  tail -n +2 >> "$3"
+  curl "${CURL_ARGS[@]}" "${API}&isin=$1&page=$2&per_page=$PER_PAGE" | \
+  jq --raw-output '.data[] | [.field_isin, .isin_description__value, .name, .security_description, .isin_status] | map(. // "") | @csv' >> "$3"
 }
-function fetch_total_pages() {
-  # https://whatsmychaincert.com/?nsdl.co.in 
-  # NSDL.co.in is missing the intermediate chain cert
-  # so we allow the intermediate (src/GeoTrustTLSRSACAG1.crt.pem)
-  curl --insecure "https://nsdl.co.in/master_search_res.php" \
-    --user-agent "Mozilla/Gecko/Firefox/58.0" \
-    --silent \
-    --cacert src/GeoTrustTLSRSACAG1.crt.pem \
-    --data cnum=$1 \
-    --data "page_no=1" |
-  $PUP_BINARY 'input[name=total_page] attr{value}'
+
+function fetch_count() {
+  # jq -e fails on missing/null .count so an API change can't silently become 0 pages
+  curl "${CURL_ARGS[@]}" "${API}&isin=$1&page=1&per_page=1" | jq -er '.count'
 }
-export -f fetch_page
 
 function fetch_class() {
   local class="$1"
@@ -54,18 +27,19 @@ function fetch_class() {
   if [ "$partial" = "1" ] && [ "$total" -gt 500 ]; then
     # Date-indexed partial fetch: fetch only pages where (page_no % 100) == (day_of_year % 100).
     # All pages get covered every 100 days (~3-4 hits/year on a daily schedule).
+    # With per_page=50000 this rarely triggers; it's a guard in case the API caps page size.
     local doy
     doy=$(date +%-j)
     local bucket=$((doy % 100))
     echo "[partial] $class: bucket $bucket/100 (day-of-year $doy)"
     for i in $(seq 1 "$total"); do
       if [ $((i % 100)) -eq "$bucket" ]; then
-        sem -j 10 --timeout 500% fetch_page "$class" "$i" "$class.csv"
+        fetch_page "$class" "$i" "$class.csv"
       fi
     done
   else
     for i in $(seq 1 "$total"); do
-      sem -j 10 --timeout 500% fetch_page "$class" "$i" "$class.csv"
+      fetch_page "$class" "$i" "$class.csv"
     done
   fi
 }
@@ -83,17 +57,27 @@ if [ -z "$CLASS" ]; then
   exit 1
 fi
 
-total=$(fetch_total_pages "$CLASS")
-echo "::group::$CLASS (Total=$total, partial=$PARTIAL_OK)"
+count=$(fetch_count "$CLASS")
+total=$(( (count + PER_PAGE - 1) / PER_PAGE ))
+echo "::group::$CLASS (Count=$count, Total=$total, partial=$PARTIAL_OK)"
 rm -f "$CLASS.csv"
+touch "$CLASS.csv" # classes can legitimately have zero results
 fetch_class "$CLASS" "$total" "$PARTIAL_OK"
 echo "::endgroup::"
 
-sem --wait
+# On a full fetch, rows must match the reported count (1% slack for changes
+# mid-fetch). Catches a silently capped per_page or dropped pages.
+if [ "$PARTIAL_OK" != "1" ] || [ "$total" -le 500 ]; then
+  rows=$(wc -l < "$CLASS.csv")
+  if [ "$rows" -lt $(( count * 99 / 100 )) ]; then
+    echo "::error::$CLASS: fetched $rows rows but API reports count=$count" >&2
+    exit 1
+  fi
+fi
 
 # Sort the file in place
 sort -o "$CLASS.csv" "$CLASS.csv"
 # Remove lines that don't start with the correct prefix
 # This is to avoid ISINs like INF955L01IN9 showing up under IN9
 # Note that there is a " at the beginning to account for quoted CSVs
-sed -i "/^\"$CLASS/!d" "$CLASS.csv"
+sed "/^\"$CLASS/!d" "$CLASS.csv" > "$CLASS.tmp" && mv "$CLASS.tmp" "$CLASS.csv"

--- a/src/main.py
+++ b/src/main.py
@@ -71,7 +71,9 @@ def diff(old: dict, fields: dict) -> dict:
         if not new_str:
             continue
         old_str = str(old.get(f) or "")
-        if new_str == old_str:
+        # Case-insensitive: NSDL sources differ only in casing for many records
+        # (the search API upper-cases descriptions); not a meaningful change.
+        if new_str.casefold() == old_str.casefold():
             continue
         changes[f] = {"old": old_str, "new": new_str} if old_str else {"new": new_str}
     return changes


### PR DESCRIPTION
Fixes broken update since July 1, caused by the NSDL domain migration [ref: [NSDL BSE intimation](https://www.bseindia.com/xml-data/corpfiling/AttachHis/81edc53a-506f-4831-92e2-767651e29f20.pdf)].

## Changes

- Replace the `nsdl.co.in` HTML scrape with the `nsdl.com` JSON API, which serves up to 50k rows per request. Every class now fits in ≤6 pages,  so each run fetches the full corpus (~369k rows, ~8 min). 
- Drop the `pup` binary, GNU `parallel`, and the intermediate cert.
- The new API upper-cases descriptions; so the `main.py diff()` now compares case-insensitively; otherwise this would record ~31k cosmetic isin_history  entries on the first run.

## Data notes

- **~1.9k securities flip DELETED → ACTIVE on the first run.** The new API reports them as ACTIVE for some reason. 
- No replacement found for the ISIN details CSV. Closest is an xlsx at https://nsdl.com/nsdl/2026-05/List_of_Securitised_Instruments_19.05.26.xlsx ;  happy to add support if you approve [adds `openpyxl` depdendency].